### PR TITLE
Fix examples animation split API usage and CI preferred-target flow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,8 +41,8 @@ jobs:
         run: |
           cd selene-webgpu
           moon update
-          moon check --target js --deny-warn
-          moon build --target js
+          moon check --deny-warn
+          moon build
 
       - name: selene-examples
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -60,6 +60,6 @@ jobs:
             if [ -z "$pkg" ]; then
               continue
             fi
-            echo "Checking JS target for $pkg"
-            moon check "$pkg" --target js --deny-warn
+            echo "Checking preferred target for $pkg"
+            moon -C "$pkg" check --deny-warn
           done <<< "$web_packages"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,7 +41,7 @@ jobs:
               continue
             fi
             echo "Building $pkg"
-            moon build "$pkg" --target js --release
+            moon -C "$pkg" build --release
           done <<< "$web_packages"
 
       - name: Copy example games

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,6 +73,7 @@
 - Changed `selene/physics3d` impulse `Rope/Spring` joint syncing to use generic-joint insertion (Bevy-style handle path), so these variants now expose stable impulse joint handles and share consistent `contacts_enabled` behavior with other impulse joint types.
 - Changed `selene/physics3d` collider sync to preserve threshold-derived contact-force active events during per-frame updates, and added wbtest coverage for default-vs-low `ContactForceEventThreshold` behavior.
 - Changed `selene/physics3d` revolute joint conversion to route through a generic-joint mapping path that applies `motor_model` and optional `softness`, and extended 3D wbtests with revolute/prismatic joint behavior assertions (limits + motor state + softness mapping coverage on the generic-joint path).
+- Changed CI workflows (`build`/`deploy`) to run example/web package checks and builds via `moon -C <pkg> ...` so package/module `preferred-target` is used in workspace mode instead of forcing explicit `--target js`.
 
 ### Fixed
 
@@ -91,6 +92,7 @@
 - Fixed `selene-editor` initial preview camera placement so first scene load aligns scene content to the viewport's top-left instead of leaving positive-coordinate scenes offset toward the center/right-bottom.
 - Fixed `selene-editor` initial viewport alignment race by making camera top-left alignment explicit and retryable until required camera/projection state is ready, preventing first-load misalignment when scene data arrives before full preview setup.
 - Fixed `selene-editor` workspace loading to stop silently falling back to defaults on invalid `.selene-editor/workspace.json`; project open now reports a deterministic error and preserves invalid-data visibility.
+- Fixed `examples/pixeladventure` editor scene loading to match split animation asset APIs in `selene/editor_bridge` by handling `InvalidAnimationClipAssetDocument` / `InvalidAnimationGraphAssetDocument` and wiring `animation_clip_assets` + `animation_graph_assets`.
 
 ### Removed
 

--- a/examples/pixeladventure/editor_scene.mbt
+++ b/examples/pixeladventure/editor_scene.mbt
@@ -73,8 +73,10 @@ fn load_pixeladventure_project_bundle() -> @editor_bridge.ProjectBundle {
       abort("Invalid pixeladventure startup scene: " + message)
     @editor_bridge.InvalidAtlasAssetDocument(message) =>
       abort("Invalid pixeladventure atlas asset: " + message)
-    @editor_bridge.InvalidAnimationAssetDocument(message) =>
-      abort("Invalid pixeladventure animation asset: " + message)
+    @editor_bridge.InvalidAnimationClipAssetDocument(message) =>
+      abort("Invalid pixeladventure animation clip asset: " + message)
+    @editor_bridge.InvalidAnimationGraphAssetDocument(message) =>
+      abort("Invalid pixeladventure animation graph asset: " + message)
     err =>
       abort("Failed to load pixeladventure scene bundle: " + err.to_string())
   }
@@ -305,7 +307,8 @@ fn load_level_scene() -> LoadedLevelScene {
   let scene = bundle.scene
   let context = @editor_bridge.asset_instantiation_context(
     atlas_assets=bundle.atlas_assets,
-    animation_assets=bundle.animation_assets,
+    animation_clip_assets=bundle.animation_clip_assets,
+    animation_graph_assets=bundle.animation_graph_assets,
     custom_component_appliers=pixeladventure_custom_component_appliers(),
   )
   let runtime = @editor_bridge.instantiate_scene_document_with_context(


### PR DESCRIPTION
Summary
- Fix examples/pixeladventure/editor_scene.mbt for split animation asset APIs in selene/editor_bridge.
- Handle InvalidAnimationClipAssetDocument and InvalidAnimationGraphAssetDocument.
- Pass animation_clip_assets and animation_graph_assets into asset instantiation context.
- Update CI workflows to follow package preferred-target in workspace mode.
- build.yaml: remove forced target js for selene-webgpu and check examples via moon -C <pkg> check --deny-warn.
- deploy.yaml: build examples via moon -C <pkg> build --release.
- Update docs/CHANGELOG.md under Unreleased.

Verification
- cd examples && moon -C ./cards/web check --deny-warn
- cd examples && moon -C ./pixeladventure/web check --deny-warn
- cd examples && moon -C ./scene3d/web check --deny-warn
- cd examples && moon -C ./survivors/web check --deny-warn
- cd selene-webgpu && moon check --deny-warn && moon build