### PR TITLE
fix: decode map asset text as UTF-8

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Changed embedded shader/source strings to use MoonBit multiline string syntax instead of `\n` string concatenation.
 
 ### Fixed
-- Fixed Tiled map loading to decode asset bytes as UTF-8 before parsing JSON or XML map sources.
+- Fixed Tiled and LDtk loading to decode asset bytes as UTF-8 before parsing text map sources.
 
 ### Removed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed embedded shader/source strings to use MoonBit multiline string syntax instead of `\n` string concatenation.
 
 ### Fixed
+- Fixed Tiled map loading to decode asset bytes as UTF-8 before parsing JSON or XML map sources.
 
 ### Removed
 

--- a/selene-core/src/ldtk/ldtk_parser_levels.mbt
+++ b/selene-core/src/ldtk/ldtk_parser_levels.mbt
@@ -256,10 +256,8 @@ fn unique_ldtk_iids(iids : Array[String]) -> Array[String] {
 
 ///|
 fn load_ldtk_text_document(path : String) -> String? {
-  if @asset.read_bytes(path) is Some(bytes) {
-    return Some(bytes.to_unchecked_string())
-  }
-  @asset.read_bytes(path).map(bytes => bytes.to_unchecked_string())
+  guard @asset.read_bytes(path) is Some(bytes) else { return None }
+  Some(@encoding/utf8.decode(bytes) catch { _ => return None })
 }
 
 ///|

--- a/selene-core/src/ldtk/ldtk_wbtest.mbt
+++ b/selene-core/src/ldtk/ldtk_wbtest.mbt
@@ -4,7 +4,6 @@ fn ascii_bytes(source : String) -> Bytes {
   for ch in source.to_array() {
     let code = ch.to_int()
     bytes.push((code & 0xFF).to_byte())
-    bytes.push((code >> 8).to_byte())
   }
   Bytes::from_array(bytes[:])
 }
@@ -17,6 +16,23 @@ fn with_fake_asset_io(
   @asset.set_io(fn(path) { files.get(path) })
   body()
   @asset.set_io(fn(_path) { None })
+}
+
+///|
+test "load_ldtk_project reads UTF-8 LDtk asset bytes" {
+  let files : Map[String, Bytes] = Map([])
+  files.set(
+    "levels/world.ldtk",
+    ascii_bytes(
+      "{\"externalLevels\":false,\"levels\":[{\"identifier\":\"A\",\"iid\":\"iid-a\",\"uid\":1,\"worldX\":12,\"worldY\":34,\"pxWid\":320,\"pxHei\":240,\"layerInstances\":[]}],\"defs\":{\"tilesets\":[]}}",
+    ),
+  )
+  with_fake_asset_io(files, fn() raise {
+    let project = load_ldtk_project("levels/world.ldtk")
+    inspect(project.levels.length(), content="1")
+    inspect(project.levels[0].identifier, content="A")
+    inspect(project.levels[0].iid, content="iid-a")
+  })
 }
 
 ///|

--- a/selene-core/src/ldtk/moon.pkg
+++ b/selene-core/src/ldtk/moon.pkg
@@ -11,5 +11,6 @@ import {
   "Milky2018/selene/transform",
   "Milky2018/selene/visibility",
   "moonbitlang/core/json",
+  "moonbitlang/core/encoding/utf8" @encoding/utf8,
   "moonbitlang/core/string",
 }

--- a/selene-core/src/tiled/moon.pkg
+++ b/selene-core/src/tiled/moon.pkg
@@ -21,6 +21,7 @@ import {
   "gmlewis/gzip",
   "gmlewis/io",
   "moonbitlang/core/json",
+  "moonbitlang/core/encoding/utf8" @encoding/utf8,
   "moonbitlang/core/math" @cmath,
   "moonbitlang/core/string",
   "moonbitlang/x/fs",

--- a/selene-core/src/tiled/tiled.mbt
+++ b/selene-core/src/tiled/tiled.mbt
@@ -563,7 +563,7 @@ fn parse_layers(layers_json : Json?) -> Array[TiledLayer] {
 ///|
 fn load_tiled_text_document(path : String) -> String? {
   guard @asset.read_bytes(path) is Some(bytes) else { return None }
-  Some(bytes.to_unchecked_string())
+  Some(@encoding/utf8.decode(bytes) catch { _ => return None })
 }
 
 ///|

--- a/selene-core/src/tiled/tiled_wbtest.mbt
+++ b/selene-core/src/tiled/tiled_wbtest.mbt
@@ -4,7 +4,6 @@ fn ascii_bytes(source : String) -> Bytes {
   for ch in source.to_array() {
     let code = ch.to_int()
     bytes.push((code & 0xFF).to_byte())
-    bytes.push((code >> 8).to_byte())
   }
   Bytes::from_array(bytes[:])
 }
@@ -23,6 +22,23 @@ fn with_fake_asset_io(
 fn cleanup_spawned_tiled_tree(root : @entity.Entity) -> Unit {
   despawn_tiled_tree(root)
   @entity.entity_flush_system(0.0)
+}
+
+///|
+test "load_tiled_map reads UTF-8 TMJ asset bytes" {
+  let files : Map[String, Bytes] = Map([])
+  files.set(
+    "maps/demo.tmj",
+    ascii_bytes(
+      "{\"width\":1,\"height\":1,\"tilewidth\":16,\"tileheight\":16,\"layers\":[],\"tilesets\":[]}",
+    ),
+  )
+  with_fake_asset_io(files, fn() raise {
+    let map = load_tiled_map("maps/demo.tmj")
+    inspect(map.width, content="1")
+    inspect(map.height, content="1")
+    inspect(map.layers.length(), content="0")
+  })
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Decode Tiled and LDtk text asset bytes as UTF-8 before parsing map sources.
- Update the fake asset byte helpers to model normal one-byte ASCII file contents.
- Add focused regression tests for loading UTF-8 TMJ and LDtk assets.

## Root Cause

`load_tiled_map` converted asset bytes with `Bytes::to_unchecked_string()`. Normal file-backed asset readers return UTF-8 bytes, so valid TMJ JSON could fail parsing and silently produce `empty_tiled_map()`.

LDtk used the same unchecked byte-to-string conversion path, so this PR fixes that analogous text asset loader too.

Fixes #36

## Checks

- `moon check --target native --diagnostic-limit 200 selene-core/src/ldtk selene-core/src/tiled`
- `moon check --target js --diagnostic-limit 200 selene-core/src/ldtk selene-core/src/tiled`
- `moon test --target native --diagnostic-limit 200 selene-core/src/ldtk selene-core/src/tiled`
- `moon test --target js --diagnostic-limit 200 selene-core/src/ldtk selene-core/src/tiled`