### PR TITLE
fix(tiled): support standard parallax and image size fields

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed embedded shader/source strings to use MoonBit multiline string syntax instead of `\n` string concatenation.
 
 ### Fixed
+- Fixed Tiled map spawning to preserve map parallax origins and image-layer dimensions from TMJ/TMX files.
 
 ### Removed
 

--- a/selene-core/src/tiled/ecs.mbt
+++ b/selene-core/src/tiled/ecs.mbt
@@ -443,7 +443,7 @@ fn spawn_tiled_layers(
       @math.Vec2(layer.offset_x, layer.offset_y),
     )
     tiled_ecs_set_entity_visibility(layer_entity, effective_visible)
-    tiled_register_parallax_layer(layer_entity, layer)
+    tiled_register_parallax_layer(layer_entity, map, layer)
     tiled_layer_instances().set(layer_entity, {
       map_entity,
       layer,
@@ -658,11 +658,20 @@ fn spawn_tiled_image_layer(
   tiled_ecs_set_entity_depth(layer_entity, zindex)
   tiled_ecs_set_entity_visibility(layer_entity, visible)
   let repeat = tiled_image_repeat_mode(image_layer)
+  let custom_size = if repeat is NoRepeat &&
+    image_layer.image_width is Some(width) &&
+    image_layer.image_height is Some(height) &&
+    width > 0 &&
+    height > 0 {
+    @math.Vec2(width.to_double(), height.to_double())
+  } else {
+    tiled_map_world_size(map)
+  }
   @sprite.sprites().set(
     layer_entity,
     @sprite.Sprite(
       image=Some(load_tiled_image(image_path)),
-      custom_size=Some(tiled_map_world_size(map)),
+      custom_size=Some(custom_size),
       color=@render.Color::{ r: 255U, g: 255U, b: 255U, a: layer.opacity },
       anchor=@sprite.Anchor(@math.Vec2(-0.5, 0.5)),
       image_mode=@sprite.Tiled(repeat),
@@ -1115,14 +1124,44 @@ fn load_tiled_image(path : String) -> @asset.ImageHandle {
 
 ///|
 pub fn tiled_parallax_system(_delta : Double) -> Unit {
+  let camera_view = @camera.primary_camera2d_view()
   for pair in tiled_parallax_layers().to_array() {
     let layer_entity = pair.0
-    ignore(pair.1)
+    let layer = pair.1
     if !layer_entity.is_alive() {
       tiled_parallax_layers().remove(layer_entity)
       @parallax2d.parallax2ds().remove(layer_entity)
+    } else if @parallax2d.parallax2ds().get(layer_entity) is Some(parallax) {
+      guard tiled_layer_instances().get(layer_entity) is Some(layer_instance) else {
+        continue
+      }
+      guard tiled_map_instances().get(layer_instance.map_entity)
+        is Some(map_instance) else {
+        continue
+      }
+      let base_offset = tiled_parallax_base_offset(
+        map_instance.map,
+        layer_instance.layer,
+        camera_view,
+      )
+      tiled_parallax_layers().set(layer_entity, { ..layer, base_offset, })
+      @parallax2d.parallax2ds().set(layer_entity, { ..parallax, base_offset, })
     }
   }
+}
+
+///|
+fn tiled_parallax_base_offset(
+  map : TiledMap,
+  layer : TiledLayer,
+  camera_view : @camera.Camera2dView?,
+) -> @math.Vec2 {
+  guard camera_view is Some(camera_view) else { return @math.Vec2::zero() }
+  let view_half = camera_view.world_bounds().size.scalar_mul(0.5)
+  @math.Vec2(
+    (1.0 - layer.parallax_x) * (view_half[X] + map.parallax_origin_x),
+    (1.0 - layer.parallax_y) * (view_half[Y] + map.parallax_origin_y),
+  )
 }
 
 ///|
@@ -1191,13 +1230,18 @@ fn tiled_set_tile_properties(
 ///|
 fn tiled_register_parallax_layer(
   layer_entity : @entity.Entity,
+  map : TiledMap,
   layer : TiledLayer,
 ) -> Unit {
   if layer.parallax_x == 1.0 && layer.parallax_y == 1.0 {
     @parallax2d.parallax2ds().remove(layer_entity)
     return
   }
-  let base_offset = @math.Vec2(layer.offset_x, layer.offset_y)
+  let base_offset = tiled_parallax_base_offset(
+    map,
+    layer,
+    @camera.primary_camera2d_view(),
+  )
   tiled_parallax_layers().set(layer_entity, {
     base_offset,
     parallax_x: layer.parallax_x,
@@ -1206,6 +1250,7 @@ fn tiled_register_parallax_layer(
   @parallax2d.parallax2ds().set(
     layer_entity,
     @parallax2d.Parallax2d(
+      base_offset~,
       factor=@math.Vec2(layer.parallax_x, layer.parallax_y),
     ),
   )

--- a/selene-core/src/tiled/pkg.generated.mbti
+++ b/selene-core/src/tiled/pkg.generated.mbti
@@ -155,6 +155,8 @@ pub fn TiledGid::is_empty(Self) -> Bool
 pub struct TiledImageLayer {
   image : String?
   transparent_color : String?
+  image_width : Int?
+  image_height : Int?
   repeat_x : Bool
   repeat_y : Bool
 }
@@ -219,6 +221,8 @@ pub struct TiledMap {
   height : Int
   tile_width : Int
   tile_height : Int
+  parallax_origin_x : Double
+  parallax_origin_y : Double
   hex_side_length : Int?
   stagger_axis : String?
   stagger_index : String?

--- a/selene-core/src/tiled/tiled.mbt
+++ b/selene-core/src/tiled/tiled.mbt
@@ -135,6 +135,8 @@ pub struct TiledObjectLayer {
 pub struct TiledImageLayer {
   image : String?
   transparent_color : String?
+  image_width : Int?
+  image_height : Int?
   repeat_x : Bool
   repeat_y : Bool
 }
@@ -208,6 +210,8 @@ pub struct TiledMap {
   height : Int
   tile_width : Int
   tile_height : Int
+  parallax_origin_x : Double
+  parallax_origin_y : Double
   hex_side_length : Int?
   stagger_axis : String?
   stagger_index : String?
@@ -275,6 +279,8 @@ pub fn empty_tiled_map() -> TiledMap {
     height: 0,
     tile_width: 0,
     tile_height: 0,
+    parallax_origin_x: 0.0,
+    parallax_origin_y: 0.0,
     hex_side_length: None,
     stagger_axis: None,
     stagger_index: None,
@@ -308,6 +314,12 @@ pub fn TiledMap::from_tiled_json(json : Json) -> TiledMap {
     height: field_int(root_object, "height").unwrap_or(0),
     tile_width: field_int(root_object, "tilewidth").unwrap_or(0),
     tile_height: field_int(root_object, "tileheight").unwrap_or(0),
+    parallax_origin_x: field_number(root_object, "parallaxoriginx").unwrap_or(
+      0.0,
+    ),
+    parallax_origin_y: field_number(root_object, "parallaxoriginy").unwrap_or(
+      0.0,
+    ),
     hex_side_length: field_int(root_object, "hexsidelength"),
     stagger_axis: field_string(root_object, "staggeraxis"),
     stagger_index: field_string(root_object, "staggerindex"),
@@ -999,6 +1011,8 @@ fn parse_image_layer(layer_object : Map[String, Json]) -> TiledImageLayer {
   {
     image: field_string(layer_object, "image"),
     transparent_color: field_string(layer_object, "transparentcolor"),
+    image_width: field_int(layer_object, "imagewidth"),
+    image_height: field_int(layer_object, "imageheight"),
     repeat_x: field_bool(layer_object, "repeatx").unwrap_or(false),
     repeat_y: field_bool(layer_object, "repeaty").unwrap_or(false),
   }

--- a/selene-core/src/tiled/tiled_wbtest.mbt
+++ b/selene-core/src/tiled/tiled_wbtest.mbt
@@ -450,6 +450,102 @@ test "spawn_tiled_map creates tile object and image layer entities" {
 }
 
 ///|
+test "spawn_tiled_map imagelayer without repeat uses image dimensions" {
+  let files : Map[String, Bytes] = Map([])
+  files.set(
+    "maps/image-size.tmj",
+    ascii_bytes(
+      "{\"width\":2,\"height\":2,\"tilewidth\":16,\"tileheight\":16,\"layers\":[{\"id\":1,\"name\":\"Backdrop\",\"type\":\"imagelayer\",\"image\":\"bg.png\",\"imagewidth\":24,\"imageheight\":12}],\"tilesets\":[]}",
+    ),
+  )
+  files.set("maps/bg.png", ascii_bytes("png"))
+  with_fake_asset_io(files, fn() raise {
+    let root = load_and_spawn_tiled_map("maps/image-size.tmj")
+    defer cleanup_spawned_tiled_tree(root)
+    let layer_entity = tiled_layer_instances()
+      .to_array()
+      .filter(fn(pair) { pair.1.map_entity == root })[0].0
+    guard @sprite.sprites().get(layer_entity) is Some(sprite) else {
+      fail("missing image layer sprite")
+    }
+    inspect(
+      match sprite.custom_size {
+        Some(size) => vec2_snapshot(size) == "24,12"
+        None => false
+      },
+      content="true",
+    )
+  })
+}
+
+///|
+test "spawn_tiled_map imagelayer without repeat falls back to map size when image size missing" {
+  let files : Map[String, Bytes] = Map([])
+  files.set(
+    "maps/no-repeat.tmj",
+    ascii_bytes(
+      "{\"width\":2,\"height\":2,\"tilewidth\":16,\"tileheight\":16,\"layers\":[{\"id\":1,\"name\":\"Backdrop\",\"type\":\"imagelayer\",\"image\":\"bg.png\"}],\"tilesets\":[]}",
+    ),
+  )
+  files.set("maps/bg.png", ascii_bytes("png"))
+  with_fake_asset_io(files, fn() raise {
+    let root = load_and_spawn_tiled_map("maps/no-repeat.tmj")
+    defer cleanup_spawned_tiled_tree(root)
+    let layer_entity = tiled_layer_instances()
+      .to_array()
+      .filter(fn(pair) { pair.1.map_entity == root })[0].0
+    guard @sprite.sprites().get(layer_entity) is Some(sprite) else {
+      fail("missing image layer sprite")
+    }
+    inspect(
+      match sprite.custom_size {
+        Some(size) => vec2_snapshot(size) == "32,32"
+        None => false
+      },
+      content="true",
+    )
+  })
+}
+
+///|
+test "load_tiled_map reads TMX parallax origin and imagelayer dimensions" {
+  let files : Map[String, Bytes] = Map([])
+  let xml =
+    #|<?xml version="1.0" encoding="UTF-8"?>
+    #|<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="1" height="1" tilewidth="16" tileheight="16" parallaxoriginx="10" parallaxoriginy="-20">
+    #|  <imagelayer id="1" name="Backdrop">
+    #|    <image source="bg.png" width="24" height="12"/>
+    #|  </imagelayer>
+    #|</map>
+    #|
+  files.set("maps/image-size.tmx", ascii_bytes(xml))
+  with_fake_asset_io(files, fn() raise {
+    let map = load_tiled_map("maps/image-size.tmx")
+    inspect(map.parallax_origin_x.to_int(), content="10")
+    inspect(map.parallax_origin_y.to_int(), content="-20")
+    match map.layers[0].kind {
+      ImageLayer(image_layer) => {
+        inspect(
+          match image_layer.image_width {
+            Some(width) => width == 24
+            None => false
+          },
+          content="true",
+        )
+        inspect(
+          match image_layer.image_height {
+            Some(height) => height == 12
+            None => false
+          },
+          content="true",
+        )
+      }
+      _ => fail("missing image layer")
+    }
+  })
+}
+
+///|
 test "respawn_tiled_map_into_entity replaces previous tiled children and metadata" {
   let files : Map[String, Bytes] = Map([])
   files.set(
@@ -1033,7 +1129,7 @@ test "tiled parallax system adjusts layer offsets" {
   files.set(
     "maps/parallax.tmj",
     ascii_bytes(
-      "{\"width\":1,\"height\":1,\"tilewidth\":16,\"tileheight\":16,\"layers\":[{\"id\":1,\"name\":\"Background\",\"type\":\"tilelayer\",\"offsetx\":2,\"offsety\":3,\"parallaxx\":0.5,\"parallaxy\":0.0,\"width\":1,\"height\":1,\"data\":[0]}],\"tilesets\":[]}",
+      "{\"width\":1,\"height\":1,\"tilewidth\":16,\"tileheight\":16,\"parallaxoriginx\":10,\"parallaxoriginy\":-20,\"layers\":[{\"id\":1,\"name\":\"Background\",\"type\":\"tilelayer\",\"offsetx\":2,\"offsety\":3,\"parallaxx\":0.5,\"parallaxy\":0.0,\"width\":1,\"height\":1,\"data\":[0]}],\"tilesets\":[]}",
     ),
   )
   with_fake_asset_io(files, fn() raise {
@@ -1055,7 +1151,7 @@ test "tiled parallax system adjusts layer offsets" {
           Some(first_camera_view),
         ),
       ),
-      content="2,3",
+      content="32,33",
     )
 
     tiled_test_set_entity_translation_2d(
@@ -1064,16 +1160,17 @@ test "tiled parallax system adjusts layer offsets" {
     )
     tiled_parallax_system(0.0)
     let second_camera_view = @camera.primary_camera2d_view().unwrap()
+    let moved_parallax = @parallax2d.inherited_parallax2d(layer_entity).unwrap()
 
     inspect(
       vec2_snapshot(
         @parallax2d.parallax_world_position(
           tiled_test_entity_translation_2d(layer_entity),
-          Some(parallax),
+          Some(moved_parallax),
           Some(second_camera_view),
         ),
       ),
-      content="102,103",
+      content="132,133",
     )
   })
 

--- a/selene-core/src/tiled/tiled_xml.mbt
+++ b/selene-core/src/tiled/tiled_xml.mbt
@@ -130,6 +130,8 @@ fn parse_tiled_xml_map(root : TiledXmlNode) -> TiledMap {
     height: xml_int_attr(root, "height").unwrap_or(0),
     tile_width: xml_int_attr(root, "tilewidth").unwrap_or(0),
     tile_height: xml_int_attr(root, "tileheight").unwrap_or(0),
+    parallax_origin_x: xml_double_attr(root, "parallaxoriginx").unwrap_or(0.0),
+    parallax_origin_y: xml_double_attr(root, "parallaxoriginy").unwrap_or(0.0),
     hex_side_length: xml_int_attr(root, "hexsidelength"),
     stagger_axis: xml_attr(root, "staggeraxis"),
     stagger_index: xml_attr(root, "staggerindex"),
@@ -348,6 +350,8 @@ fn parse_tiled_xml_image_layer(node : TiledXmlNode) -> TiledImageLayer {
   {
     image: image.bind(fn(img) { xml_attr(img, "source") }),
     transparent_color: image.bind(fn(img) { xml_attr(img, "trans") }),
+    image_width: image.bind(fn(img) { xml_int_attr(img, "width") }),
+    image_height: image.bind(fn(img) { xml_int_attr(img, "height") }),
     repeat_x: xml_bool_attr(node, "repeatx").unwrap_or(false),
     repeat_y: xml_bool_attr(node, "repeaty").unwrap_or(false),
   }


### PR DESCRIPTION
## Summary

- preserve Tiled map parallax origins from TMJ and TMX files
- preserve image layer dimensions from TMJ and TMX files
- use those fields when spawning Tiled parallax layers and non-repeated image layers

## Root Cause

Selene parsed many standard Tiled document fields, but dropped map-level parallax origin fields and image-layer image dimensions. The runtime then had no data to align parallax placement or non-repeated image-layer sizing with Tiled Editor output.

Fixes #38

## Checks

- moon check --target native --diagnostic-limit 200 selene-core/src/tiled
- moon check --target js --diagnostic-limit 200 selene-core/src/tiled
- moon test --target native --diagnostic-limit 200 selene-core/src/tiled
- moon test --target js --diagnostic-limit 200 selene-core/src/tiled