### PR TITLE
fix(raylib): flip offscreen capture readback

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed embedded shader/source strings to use MoonBit multiline string syntax instead of `\n` string concatenation.
 
 ### Fixed
+- Fixed raylib offscreen render captures so exported PNGs match the rendered vertical orientation.
 
 ### Removed
 

--- a/selene-raylib/src/platform_render/moon.pkg
+++ b/selene-raylib/src/platform_render/moon.pkg
@@ -4,7 +4,7 @@ import {
   "Milky2018/selene/render2d_types",
   "Milky2018/selene/render_pipeline",
   "Milky2018/selene_raylib" @impl,
-  "tonyfettes/raylib" @raylib,
+  "tonyfettes/raylib",
   "moonbitlang/core/cmp",
   "moonbitlang/core/math" @cmath,
   "moonbitlang/core/set",

--- a/selene-raylib/src/platform_render/top.mbt
+++ b/selene-raylib/src/platform_render/top.mbt
@@ -220,6 +220,8 @@ pub fn render_offscreen_png(
     image.unload()
     return None
   }
+  // RenderTexture pixels are read back in OpenGL bottom-up order.
+  image.flip_vertical()
   let bytes = image.export_to_memory(".png")
   image.unload()
   if bytes.length() == 0 {


### PR DESCRIPTION
## Summary

- flip raylib RenderTexture readback before exporting offscreen capture PNGs
- document the raylib offscreen capture orientation fix in the changelog

## Root Cause

Raylib RenderTexture pixels are read back in OpenGL bottom-up order. `render_offscreen_png` exported that image directly, so offscreen captures were vertically inverted compared with normal rendering.

Fixes #40

## Checks

- moon check --target native --diagnostic-limit 200 selene-raylib/src

I did not add an image integration test because this path depends on raylib RenderTexture readback behavior.
