### PR TITLE
fix(tiled): expose spawn settings construction

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed embedded shader/source strings to use MoonBit multiline string syntax instead of `\n` string concatenation.
 
 ### Fixed
+- Fixed `TiledSpawnSettings` so external packages can configure Tiled spawn hooks with record updates.
 
 ### Removed
 

--- a/selene-core/src/tiled/ecs.mbt
+++ b/selene-core/src/tiled/ecs.mbt
@@ -163,7 +163,7 @@ fn tiled_install_sprite_animation(
 }
 
 ///|
-pub struct TiledSpawnSettings {
+pub(all) struct TiledSpawnSettings {
   position : @math.Vec2
   zindex : Int
   layer_z_step : Int

--- a/selene-core/src/tiled/pkg.generated.mbti
+++ b/selene-core/src/tiled/pkg.generated.mbti
@@ -357,7 +357,7 @@ pub enum TiledPropertyValue {
   Custom(Json)
 }
 
-pub struct TiledSpawnSettings {
+pub(all) struct TiledSpawnSettings {
   position : @math.Vec2
   zindex : Int
   layer_z_step : Int


### PR DESCRIPTION
## Summary

- expose `TiledSpawnSettings` as `pub(all)` so external packages can configure spawn hooks with record updates
- update the generated Tiled package interface
- document the API usability fix in the changelog

## Root Cause

`default_tiled_spawn_settings()` returned a settings value with hook fields, but the `TiledSpawnSettings` type was externally read-only. External callers could receive the default settings but could not update fields such as `image_layer_hook`.

Fixes #41

## Checks

- moon check --target native --diagnostic-limit 200 selene-core/src/tiled
- moon check --target js --diagnostic-limit 200 selene-core/src/tiled
- moon test --target native --diagnostic-limit 200 selene-core/src/tiled
- moon test --target js --diagnostic-limit 200 selene-core/src/tiled
