### PR TITLE
feat(app): capture selected frames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added 3D collider wireframe debug rendering through the debug plugin and render3d pipeline.
+- Added `capture_frame_indexes` to `App::run_frames_capture` so tests can capture selected frames.
 
 ### Changed
 - Changed embedded shader/source strings to use MoonBit multiline string syntax instead of `\n` string concatenation.

--- a/selene-core/src/app/pkg.generated.mbti
+++ b/selene-core/src/app/pkg.generated.mbti
@@ -34,7 +34,7 @@ pub fn App::add_system(Self, @system.Schedule, (@ecs.World) -> Unit, system_name
 pub fn App::add_systems(Self, @system.Schedule, Array[(@ecs.World) -> Unit], in_set? : @system_set.SystemSet, before? : Array[@system_set.SystemSet], after? : Array[@system_set.SystemSet], run_if? : (@ecs.World) -> Bool) -> Self
 pub fn App::run(Self) -> Unit
 pub fn App::run_frames(Self, Int, raw_delta? : Double, fixed_delta_override? : Double?) -> Unit
-pub fn App::run_frames_capture(Self, Int, capture_width? : Int, capture_height? : Int, raw_delta? : Double, fixed_delta_override? : Double?, metadata_indent? : Int) -> Array[@runtime_debug.FrameCaptureArtifact]
+pub fn App::run_frames_capture(Self, Int, capture_width? : Int, capture_height? : Int, raw_delta? : Double, fixed_delta_override? : Double?, metadata_indent? : Int, capture_frame_indexes? : Array[Int]?) -> Array[@runtime_debug.FrameCaptureArtifact]
 pub fn App::step_fixed(Self, Int, fixed_delta_override? : Double?) -> Unit
 pub fn App::with_fixed_hz(Self, UInt) -> Self
 pub fn App::with_fps(Self, UInt) -> Self

--- a/selene-core/src/app/top.mbt
+++ b/selene-core/src/app/top.mbt
@@ -737,11 +737,21 @@ pub fn App::run_frames_capture(
   raw_delta? : Double = 1.0 / DEFAULT_FPS.to_double(),
   fixed_delta_override? : Double? = None,
   metadata_indent? : Int = 2,
+  capture_frame_indexes? : Array[Int]? = None,
 ) -> Array[@runtime_debug.FrameCaptureArtifact] {
   let captures : Array[@runtime_debug.FrameCaptureArtifact] = []
   if frames <= 0 {
     return captures
   }
+  let selected_frames = match capture_frame_indexes {
+    Some(indexes) => {
+      let selected = indexes.copy()
+      selected.sort_by(fn(lhs, rhs) { lhs - rhs })
+      Some(selected)
+    }
+    None => None
+  }
+  let mut next_selected_frame = 0
   setup_runtime_world(self)
   let plan = build_runtime_plan(self, fixed_delta_override~)
   startup_runtime(plan)
@@ -756,7 +766,7 @@ pub fn App::run_frames_capture(
     capture_height,
     self.viewport_height * self.zoom,
   )
-  for _ in 0..<frames {
+  for frame_index in 0..<frames {
     run_headless_frame(
       plan,
       accumulator,
@@ -764,6 +774,28 @@ pub fn App::run_frames_capture(
       None,
       @platform_audio.tick,
     )
+    let should_capture = match selected_frames {
+      None => true
+      Some(indexes) => {
+        while next_selected_frame < indexes.length() &&
+              indexes[next_selected_frame] < frame_index {
+          next_selected_frame += 1
+        }
+        if next_selected_frame < indexes.length() &&
+          indexes[next_selected_frame] == frame_index {
+          while next_selected_frame < indexes.length() &&
+                indexes[next_selected_frame] == frame_index {
+            next_selected_frame += 1
+          }
+          true
+        } else {
+          false
+        }
+      }
+    }
+    if !should_capture {
+      continue
+    }
     if @runtime_debug.capture_last_frame_with_metadata(
         resolved_width,
         resolved_height,

--- a/selene-core/src/app/top_wbtest.mbt
+++ b/selene-core/src/app/top_wbtest.mbt
@@ -200,6 +200,28 @@ test "app: run_frames_capture provides a generic capture pipeline without game-s
 }
 
 ///|
+test "app: run_frames_capture accepts selected frame indexes" {
+  let world = @ecs.World()
+  let rendered_frames : Array[Int] = []
+  let app = App()
+    .with_world(world)
+    .add_system(
+      @system.Render,
+      fn(_world) { rendered_frames.push(rendered_frames.length()) },
+      system_name="render_frame_counter",
+    )
+  let captures = app.run_frames_capture(
+    4,
+    capture_width=64,
+    capture_height=64,
+    raw_delta=1.0 / 60.0,
+    capture_frame_indexes=Some([-1, 1, 1, 3, 10]),
+  )
+  inspect(rendered_frames.length(), content="4")
+  inspect(captures.length(), content="0")
+}
+
+///|
 test "app: render frame does not perform platform service work implicitly" {
   let world = @ecs.World()
   let trace : Ref[String] = { val: "" }


### PR DESCRIPTION
## Summary

- add `capture_frame_indexes` to `App::run_frames_capture`
- keep the default behavior of capturing every simulated frame when no selection is provided
- sort and de-duplicate selected frame indexes while ignoring negative and out-of-range entries naturally during the run
- cover the new API with an app whitebox test and update the generated package interface

## Motivation

Visual regression tests often only need the final frame or a few stable frames. Capturing every simulated frame creates unnecessary artifacts and extra work for callers.

Fixes #42

## Checks

- moon check --target native --diagnostic-limit 200 selene-core/src/app
- moon check --target js --diagnostic-limit 200 selene-core/src/app
- moon test --target native --diagnostic-limit 200 selene-core/src/app
- moon test --target js --diagnostic-limit 200 selene-core/src/app
