### PR TITLE
Fix nested UI offsets and nightly ToJson checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Changed
 
 ### Fixed
+- Fixed nested UI children receiving border and padding offsets twice during
+  layout projection.
 
 ### Removed
 

--- a/examples/pixeladventure/editor_scene.mbt
+++ b/examples/pixeladventure/editor_scene.mbt
@@ -56,7 +56,9 @@ fn pixeladventure_empty_component_data() -> Json {
 
 ///|
 fn terrain_component_default_data() -> Json {
-  PixelAdventureTerrainComponent::{ solid: false, collider_group: "grass" }.to_json()
+  ToJson::to_json(
+    PixelAdventureTerrainComponent::{ solid: false, collider_group: "grass" },
+  )
 }
 
 ///|

--- a/selene-core/src/editor_bridge/editor_bridge_wbtest.mbt
+++ b/selene-core/src/editor_bridge/editor_bridge_wbtest.mbt
@@ -483,7 +483,9 @@ test "custom component registry wires defaults validation and apply" {
     custom_kind,
     custom_component_handler(
       default_data=fn() {
-        RegisteredCustomComponentTestPayload::{ label: "Default Marker" }.to_json()
+        ToJson::to_json(RegisteredCustomComponentTestPayload::{
+          label: "Default Marker",
+        })
       },
       validate=fn(component, path) {
         let data : RegisteredCustomComponentTestPayload = validate_custom_component_payload(
@@ -520,7 +522,7 @@ test "custom component registry wires defaults validation and apply" {
         components: [
           component_document(
             custom_kind,
-            RegisteredCustomComponentTestPayload::{ label: "" }.to_json(),
+            ToJson::to_json(RegisteredCustomComponentTestPayload::{ label: "" }),
           ),
         ],
       },
@@ -545,7 +547,9 @@ test "custom component registry wires defaults validation and apply" {
         components: [
           component_document(
             custom_kind,
-            RegisteredCustomComponentTestPayload::{ label: "Applied Marker" }.to_json(),
+            ToJson::to_json(RegisteredCustomComponentTestPayload::{
+              label: "Applied Marker",
+            }),
           ),
         ],
       },

--- a/selene-core/src/ui/layout.mbt
+++ b/selene-core/src/ui/layout.mbt
@@ -574,7 +574,7 @@ fn apply_layout_recursive(
   entity : @entity.Entity,
   taffy : @tree.TaffyTree[@entity.Entity],
   entity_to_node_id : Map[@entity.Entity, Int],
-  parent_content_origin : @math.Vec2,
+  parent_layout_origin : @math.Vec2,
   parent_clip : @math.Rect?,
   inherited_use_rounding : Bool,
   order_counter : Ref[Int],
@@ -593,7 +593,7 @@ fn apply_layout_recursive(
     .unwrap_or(inherited_use_rounding)
   let layout = taffy.layout(node_id) catch { _ => return }
 
-  let logical_pos = parent_content_origin +
+  let logical_pos = parent_layout_origin +
     Vec2(layout.location.x, layout.location.y)
   let logical_size = @math.Vec2(layout.size.width, layout.size.height)
   let logical_rect = @math.Rect::{ position: logical_pos, size: logical_size }
@@ -676,8 +676,8 @@ fn apply_layout_recursive(
 
   let scroll = scroll_positions().get(entity).unwrap_or(ScrollPosition::zero())
   let next_origin = @math.Vec2(
-    logical_content_rect.position[X] - scroll.x,
-    logical_content_rect.position[Y] - scroll.y,
+    logical_pos[X] - scroll.x,
+    logical_pos[Y] - scroll.y,
   )
   for child in ui_children(entity) {
     apply_layout_recursive(

--- a/selene-core/src/ui/layout_wbtest.mbt
+++ b/selene-core/src/ui/layout_wbtest.mbt
@@ -243,6 +243,51 @@ test "ui layout uses overflow clip margins from the requested visual box" {
 }
 
 ///|
+test "ui layout projects nested border and padding offsets exactly once" {
+  let parent = @entity.Entity()
+  let child = parent.spawn_child()
+  let grandchild = child.spawn_child()
+  nodes().set(
+    parent,
+    Node::absolute(
+      Vec2(10.0, 20.0),
+      size=Vec2(100.0, 80.0),
+      padding=UiRectValues::all(6.0),
+      border=UiRectValues::all(2.0),
+    ),
+  )
+  nodes().set(
+    child,
+    Node(
+      width=Val::px(40.0),
+      height=Val::px(30.0),
+      padding=UiRectValues::all(3.0),
+      border=UiRectValues::all(1.0),
+    ),
+  )
+  nodes().set(grandchild, Node(width=Val::px(10.0), height=Val::px(10.0)))
+
+  ui_layout_system(0.0)
+
+  debug_inspect(
+    (
+      computed_ui_nodes().get(parent).unwrap().position,
+      computed_ui_nodes().get(parent).unwrap().content_position,
+      computed_ui_nodes().get(child).unwrap().position,
+      computed_ui_nodes().get(child).unwrap().content_position,
+      computed_ui_nodes().get(grandchild).unwrap().position,
+    ),
+    content=(
+      #|(Vec2(10, 20), Vec2(18, 28), Vec2(18, 28), Vec2(22, 32), Vec2(22, 32))
+    ),
+  )
+
+  cleanup_layout_test_entity(grandchild)
+  cleanup_layout_test_entity(child)
+  cleanup_layout_test_entity(parent)
+}
+
+///|
 test "ui layout config controls screen-space rounding for viewport-scaled rects" {
   let old_scale_mode = get_ui_scale_mode()
   let old_viewport = @system.get_viewport_size()


### PR DESCRIPTION
## Summary

- project nested UI positions from the parent layout origin and cover three-level border/padding nesting
- use explicit `ToJson::to_json` conversions where the current nightly rejects implicit promotion

Taffy child locations already include the parent content offset, so starting projection from the parent content position applied it twice. The nightly compatibility changes keep the existing bridge tests and Pixel Adventure example warning-free under `--deny-warn`.

Fixes #46.

## Checks

- `moon check --target all --deny-warn`
- selene-core CI test set: 284 passed
- `moon build` in `selene-core`