### PR TITLE
fix: clamp UI scroll positions to content bounds

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- Fixed UI scroll positions exceeding their content bounds or retaining stale offsets after layout changes.
 
 ### Removed
 

--- a/selene-core/moon.mod
+++ b/selene-core/moon.mod
@@ -5,7 +5,7 @@ version = "0.36.0"
 import {
   "Milky2018/moon_rapier@0.5.1",
   "Milky2018/moon_accesskit@0.3.0",
-  "Milky2018/moon_taffy@0.5.2",
+  "Milky2018/moon_taffy@0.5.3",
   "Milky2018/xml@0.2.0",
   "gmlewis/base64@0.16.10",
   "moonbitlang/x@0.4.45",

--- a/selene-core/src/ui/interaction.mbt
+++ b/selene-core/src/ui/interaction.mbt
@@ -609,12 +609,19 @@ pub fn ui_input_capture_system(_delta : Double) -> Unit {
 ///|
 fn apply_scroll_delta(entity : @entity.Entity, delta : @math.Vec2) -> Unit {
   guard nodes().get(entity) is Some(node) else { return }
+  guard computed_ui_nodes().get(entity) is Some(computed) else { return }
   let scroll = scroll_positions().get_or_init(entity, ScrollPosition::zero)
   if node.overflow_x == Scroll {
-    scroll.x = @cmp.maximum(0.0, scroll.x + delta[X])
+    scroll.x = @cmp.minimum(
+      computed.max_scroll_position[X],
+      @cmp.maximum(0.0, scroll.x + delta[X]),
+    )
   }
   if node.overflow_y == Scroll {
-    scroll.y = @cmp.maximum(0.0, scroll.y + delta[Y])
+    scroll.y = @cmp.minimum(
+      computed.max_scroll_position[Y],
+      @cmp.maximum(0.0, scroll.y + delta[Y]),
+    )
   }
 }
 
@@ -794,10 +801,7 @@ pub fn ui_interaction_system(_delta : Double) -> Unit {
     })
   }
   if @inputs.is_just_pressed(ArrowRight) ||
-    @inputs.is_gamepad_button_just_pressed(
-      Gamepad(0),
-      DPadRight,
-    ) {
+    @inputs.is_gamepad_button_just_pressed(Gamepad(0), DPadRight) {
     move_focus(Right)
     navigation_event_bus.send({
       entity: runtime.focused_entity,

--- a/selene-core/src/ui/interaction_wbtest.mbt
+++ b/selene-core/src/ui/interaction_wbtest.mbt
@@ -352,11 +352,17 @@ test "ui touch release outside pressed target does not click" {
 test "ui touch drag scrolls non-button scrollable panels" {
   with_ui_interaction_test_world(fn() raise {
     reset_interaction_test_state()
-    let entity = spawn_interaction_test_node(
-      { position: Vec2(0.0, 0.0), size: Vec2(100.0, 100.0) },
-      interactive=false,
-      overflow_y=Scroll,
+    let entity = @entity.Entity()
+    let child = entity.spawn_child()
+    nodes().set(
+      entity,
+      Node::absolute(Vec2(0.0, 0.0), size=Vec2(100.0, 100.0), overflow_y=Scroll),
     )
+    nodes().set(
+      child,
+      Node(width=Val::px(100.0), height=Val::px(200.0), flex_shrink=0.0),
+    )
+    ui_layout_system(0.0)
     let id = @inputs.TouchId(4)
     let previous = @math.Vec2(20.0, 50.0)
     let current = @math.Vec2(20.0, 30.0)
@@ -370,6 +376,41 @@ test "ui touch drag scrolls non-button scrollable panels" {
     let scroll = scroll_positions().get(entity).unwrap()
     inspect(scroll.y, content="20")
 
+    cleanup_interaction_test_entity(child)
+    cleanup_interaction_test_entity(entity)
+    reset_interaction_test_state()
+  })
+}
+
+///|
+test "ui scroll deltas stop at the computed content bounds" {
+  with_ui_interaction_test_world(fn() raise {
+    reset_interaction_test_state()
+    let entity = @entity.Entity()
+    let child = entity.spawn_child()
+    nodes().set(
+      entity,
+      Node::absolute(Vec2(0.0, 0.0), size=Vec2(100.0, 100.0), overflow_y=Scroll),
+    )
+    nodes().set(
+      child,
+      Node(width=Val::px(100.0), height=Val::px(220.0), flex_shrink=0.0),
+    )
+    ui_layout_system(0.0)
+
+    apply_scroll_delta(entity, Vec2(0.0, 1000.0))
+    debug_inspect(
+      [
+        computed_ui_nodes().get(entity).unwrap().max_scroll_position[Y],
+        scroll_positions().get(entity).unwrap().y,
+      ],
+      content="[120, 120]",
+    )
+
+    apply_scroll_delta(entity, Vec2(0.0, -1000.0))
+    inspect(scroll_positions().get(entity).unwrap().y, content="0")
+
+    cleanup_interaction_test_entity(child)
     cleanup_interaction_test_entity(entity)
     reset_interaction_test_state()
   })
@@ -411,10 +452,9 @@ test "ui input capture preserves pen identity" {
     let pointer : @inputs.PointerId = { source: PointerPen, value: id.value() }
     let press = @math.Vec2(120.0, 70.0)
 
-    apply_ui_touch_frame(
-      Some(touch_point(id, press, source=PointerPen)),
-      [touch_event(id, Started, press, source=PointerPen)],
-    )
+    apply_ui_touch_frame(Some(touch_point(id, press, source=PointerPen)), [
+      touch_event(id, Started, press, source=PointerPen),
+    ])
     ui_input_capture_system(0.0)
 
     inspect(is_pointer_consumed(pointer), content="true")
@@ -524,10 +564,7 @@ test "ui relative cursor positions keep normalized values outside calculated cli
   global_ui_nodes().set(entity, interaction_test_global_node(rect))
   calculated_clips().set(
     entity,
-    CalculatedClip({
-      position: Vec2(100.0, 50.0),
-      size: Vec2(10.0, 20.0),
-    }),
+    CalculatedClip({ position: Vec2(100.0, 50.0), size: Vec2(10.0, 20.0) }),
   )
   relative_cursor_positions().set(entity, RelativeCursorPosition())
   @inputs.mouse.pos = Vec2(130.0, 60.0)

--- a/selene-core/src/ui/layout.mbt
+++ b/selene-core/src/ui/layout.mbt
@@ -348,10 +348,7 @@ fn rect_intersection(lhs : @math.Rect, rhs : @math.Rect) -> @math.Rect? {
   if right <= left || bottom <= top {
     None
   } else {
-    Some({
-      position: Vec2(left, top),
-      size: Vec2(right - left, bottom - top),
-    })
+    Some({ position: Vec2(left, top), size: Vec2(right - left, bottom - top) })
   }
 }
 
@@ -404,10 +401,7 @@ fn rounded_screen_rect(rect : @math.Rect) -> @math.Rect {
   let bottom = (rect.position[Y] + rect.size[Y]).round()
   {
     position: Vec2(left, top),
-    size: Vec2(
-      @cmp.maximum(0.0, right - left),
-      @cmp.maximum(0.0, bottom - top),
-    ),
+    size: Vec2(@cmp.maximum(0.0, right - left), @cmp.maximum(0.0, bottom - top)),
   }
 }
 
@@ -626,12 +620,42 @@ fn apply_layout_recursive(
     position: content_position,
     size: content_size,
   }
+  let scroll_content_size = @math.Vec2(
+    layout.content_size.width,
+    layout.content_size.height,
+  )
+  let scrollbar_size = @math.Vec2(
+    layout.scrollbar_size.width,
+    layout.scrollbar_size.height,
+  )
+  let max_scroll_position = @math.Vec2(
+    if node.overflow_x == Scroll {
+      layout.scroll_width()
+    } else {
+      0.0
+    },
+    if node.overflow_y == Scroll {
+      layout.scroll_height()
+    } else {
+      0.0
+    },
+  )
+  let mut effective_scroll_position = @math.Vec2::zero()
+  if scroll_positions().get(entity) is Some(scroll) {
+    scroll.x = @cmp.minimum(max_scroll_position[X], @cmp.maximum(0.0, scroll.x))
+    scroll.y = @cmp.minimum(max_scroll_position[Y], @cmp.maximum(0.0, scroll.y))
+    effective_scroll_position = @math.Vec2(scroll.x, scroll.y)
+  }
 
   computed_ui_nodes().set(entity, {
     position: logical_pos,
     size: logical_size,
     content_position,
     content_size,
+    scroll_content_size,
+    scrollbar_size,
+    max_scroll_position,
+    effective_scroll_position,
     border,
     padding,
   })
@@ -674,10 +698,9 @@ fn apply_layout_recursive(
     None => calculated_clips().remove(entity)
   }
 
-  let scroll = scroll_positions().get(entity).unwrap_or(ScrollPosition::zero())
   let next_origin = @math.Vec2(
-    logical_content_rect.position[X] - scroll.x,
-    logical_content_rect.position[Y] - scroll.y,
+    logical_content_rect.position[X] - effective_scroll_position[X],
+    logical_content_rect.position[Y] - effective_scroll_position[Y],
   )
   for child in ui_children(entity) {
     apply_layout_recursive(

--- a/selene-core/src/ui/layout_wbtest.mbt
+++ b/selene-core/src/ui/layout_wbtest.mbt
@@ -287,11 +287,7 @@ test "ui target camera layouts use the camera viewport as screen-space origin" {
   let camera = @entity.Entity()
   @camera.cameras().set(
     camera,
-    Camera(
-      viewport=Some(
-        CameraViewport(Vec2(20.0, 10.0), Vec2(80.0, 40.0)),
-      ),
-    ),
+    Camera(viewport=Some(CameraViewport(Vec2(20.0, 10.0), Vec2(80.0, 40.0)))),
   )
   @camera.camera2ds().set(camera, Camera2d())
   @transform.global_transforms().set(
@@ -300,10 +296,7 @@ test "ui target camera layouts use the camera viewport as screen-space origin" {
   )
 
   let entity = @entity.Entity()
-  nodes().set(
-    entity,
-    Node::absolute(Vec2(4.0, 6.0), size=Vec2(20.0, 10.0)),
-  )
+  nodes().set(entity, Node::absolute(Vec2(4.0, 6.0), size=Vec2(20.0, 10.0)))
   ui_target_cameras().set(entity, UiTargetCamera(camera))
 
   ui_layout_system(0.0)
@@ -321,6 +314,80 @@ test "ui target camera layouts use the camera viewport as screen-space origin" {
 }
 
 ///|
+test "ui layout clamps scroll positions to overflowing content" {
+  let parent = @entity.Entity()
+  let child = parent.spawn_child()
+  nodes().set(
+    parent,
+    Node::absolute(Vec2(0.0, 0.0), size=Vec2(100.0, 100.0), overflow_y=Scroll),
+  )
+  nodes().set(
+    child,
+    Node(width=Val::px(100.0), height=Val::px(300.0), flex_shrink=0.0),
+  )
+  scroll_positions().set(parent, { x: 80.0, y: 1000.0 })
+
+  ui_layout_system(0.0)
+
+  let scroll = scroll_positions().get(parent).unwrap()
+  debug_inspect([scroll.x, scroll.y], content="[0, 200]")
+  let initial = computed_ui_nodes().get(parent).unwrap()
+  debug_inspect(
+    [
+      initial.scroll_content_size,
+      initial.max_scroll_position,
+      initial.effective_scroll_position,
+    ],
+    content="[Vec2(100, 300), Vec2(0, 200), Vec2(0, 200)]",
+  )
+
+  nodes().set(
+    parent,
+    Node::absolute(Vec2(0.0, 0.0), size=Vec2(100.0, 250.0), overflow_y=Scroll),
+  )
+  ui_layout_system(0.0)
+  let resized = computed_ui_nodes().get(parent).unwrap()
+  debug_inspect(
+    [
+      resized.max_scroll_position[Y],
+      resized.effective_scroll_position[Y],
+      scroll_positions().get(parent).unwrap().y,
+    ],
+    content="[50, 50, 50]",
+  )
+
+  nodes().set(
+    child,
+    Node(width=Val::px(100.0), height=Val::px(120.0), flex_shrink=0.0),
+  )
+  ui_layout_system(0.0)
+  let shrunk = computed_ui_nodes().get(parent).unwrap()
+  debug_inspect(
+    [shrunk.max_scroll_position[Y], scroll_positions().get(parent).unwrap().y],
+    content="[0, 0]",
+  )
+
+  nodes().set(
+    child,
+    Node(width=Val::px(100.0), height=Val::px(300.0), flex_shrink=0.0),
+  )
+  scroll_positions().set(parent, { x: 0.0, y: 70.0 })
+  nodes().set(
+    parent,
+    Node::absolute(Vec2(0.0, 0.0), size=Vec2(100.0, 100.0), overflow_y=Hidden),
+  )
+  ui_layout_system(0.0)
+  let disabled = computed_ui_nodes().get(parent).unwrap()
+  debug_inspect(
+    [disabled.max_scroll_position[Y], scroll_positions().get(parent).unwrap().y],
+    content="[0, 0]",
+  )
+
+  cleanup_layout_test_entity(child)
+  cleanup_layout_test_entity(parent)
+}
+
+///|
 test "ui override clip ignores inherited clipping rectangles" {
   let parent = @entity.Entity()
   let child = parent.spawn_child()
@@ -334,10 +401,7 @@ test "ui override clip ignores inherited clipping rectangles" {
       overflow_y=Hidden,
     ),
   )
-  nodes().set(
-    child,
-    Node::absolute(Vec2(90.0, 20.0), size=Vec2(80.0, 40.0)),
-  )
+  nodes().set(child, Node::absolute(Vec2(90.0, 20.0), size=Vec2(80.0, 40.0)))
   override_clips().set(child, OverrideClip())
 
   ui_layout_system(0.0)

--- a/selene-core/src/ui/model.mbt
+++ b/selene-core/src/ui/model.mbt
@@ -592,6 +592,10 @@ pub(all) struct ComputedUiNode {
   size : @math.Vec2
   content_position : @math.Vec2
   content_size : @math.Vec2
+  scroll_content_size : @math.Vec2
+  scrollbar_size : @math.Vec2
+  max_scroll_position : @math.Vec2
+  effective_scroll_position : @math.Vec2
   border : UiInsets
   padding : UiInsets
 }

--- a/selene-core/src/ui/pkg.generated.mbti
+++ b/selene-core/src/ui/pkg.generated.mbti
@@ -286,6 +286,10 @@ pub(all) struct ComputedUiNode {
   size : @math.Vec2
   content_position : @math.Vec2
   content_size : @math.Vec2
+  scroll_content_size : @math.Vec2
+  scrollbar_size : @math.Vec2
+  max_scroll_position : @math.Vec2
+  effective_scroll_position : @math.Vec2
   border : UiInsets
   padding : UiInsets
 }

--- a/selene-core/src/ui/render.mbt
+++ b/selene-core/src/ui/render.mbt
@@ -113,10 +113,7 @@ fn resolved_border_radius(
 ///|
 fn inset_rect(rect : @math.Rect, inset : UiInsets) -> @math.Rect {
   {
-    position: Vec2(
-      rect.position[X] + inset.left,
-      rect.position[Y] + inset.top,
-    ),
+    position: Vec2(rect.position[X] + inset.left, rect.position[Y] + inset.top),
     size: Vec2(
       @cmp.maximum(0.0, rect.size[X] - inset.left - inset.right),
       @cmp.maximum(0.0, rect.size[Y] - inset.top - inset.bottom),

--- a/selene-core/src/ui/render_wbtest.mbt
+++ b/selene-core/src/ui/render_wbtest.mbt
@@ -300,10 +300,7 @@ test "ui override clip removes inherited clip from child rendering" {
   @render2d.begin_frame2d_system(0.0)
   let parent = @entity.Entity()
   let child = parent.spawn_child()
-  nodes().set(
-    parent,
-    Node(overflow_x=Hidden, overflow_y=Hidden),
-  )
+  nodes().set(parent, Node(overflow_x=Hidden, overflow_y=Hidden))
   nodes().set(child, Node())
   global_ui_nodes().set(
     parent,


### PR DESCRIPTION
## Summary

- Derive and expose scroll content bounds during UI layout, then clamp programmatic and input-driven scroll positions to those bounds.
- Upgrade `moon_taffy` to 0.5.3 for correct container content-size aggregation and add regression coverage for resizing, overflow policy changes, and input deltas.

`ScrollPosition` was applied directly to child layout without an upper bound, while the previous layout dependency did not provide correct non-leaf content extents. This allowed content to move past its final scroll position and left stale offsets when layout sizes changed. The computed maximum and effective position now give layout, input, and future scrollbar rendering one consistent result.

Fixes #50

## Checks

- `moon check src/ui -d`
- `moon test -p Milky2018/selene/ui -d` (32 passed)