### PR TITLE
Keep UI subtrees contiguous in z-order

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Changed
 
+- Changed Selene UI stacking to tree-local ordering: `ZIndex` now orders
+  siblings while keeping ordinary descendant subtrees contiguous,
+  `GlobalZIndex` creates escapable global roots, and drawing and pointer
+  hit-testing consume the same final UI stack.
+
 ### Fixed
 
 ### Removed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Changed Selene UI stacking to tree-local ordering: `ZIndex` now orders
   siblings while keeping ordinary descendant subtrees contiguous,
   `GlobalZIndex` creates escapable global roots, and drawing and pointer
-  hit-testing consume the same final UI stack.
+  hit-testing consume the same final UI stack computed once after layout.
 
 ### Fixed
 

--- a/selene-core/src/ui/interaction.mbt
+++ b/selene-core/src/ui/interaction.mbt
@@ -255,25 +255,9 @@ fn interaction_state(
 }
 
 ///|
-fn sorted_ui_entities() -> Array[@entity.Entity] {
-  let entities : Array[@entity.Entity] = []
-  for entity, node in nodes() {
-    if entity.is_alive() &&
-      node.active &&
-      node.display != None &&
-      @visibility.is_visible(entity) &&
-      global_ui_nodes().contains(entity) {
-      entities.push(entity)
-    }
-  }
-  entities.sort_by(compare_ui_stacking)
-  entities
-}
-
-///|
 fn focusable_entities() -> Array[@entity.Entity] {
   let entities : Array[@entity.Entity] = []
-  for entity in sorted_ui_entities() {
+  for entity in ui_stack() {
     if is_focusable(entity) {
       entities.push(entity)
     }
@@ -474,7 +458,7 @@ fn update_relative_cursor_positions(position : @math.Vec2) -> Unit {
 
 ///|
 fn resolve_pointer_target(position : @math.Vec2) -> @entity.Entity? {
-  let candidates = sorted_ui_entities()
+  let candidates = ui_stack()
   let mut index = candidates.length() - 1
   while index >= 0 {
     let entity = candidates[index]
@@ -498,7 +482,7 @@ fn resolve_pointer_target(position : @math.Vec2) -> @entity.Entity? {
 
 ///|
 fn ui_node_at(position : @math.Vec2) -> @entity.Entity? {
-  let candidates = sorted_ui_entities()
+  let candidates = ui_stack()
   let mut index = candidates.length() - 1
   while index >= 0 {
     let entity = candidates[index]

--- a/selene-core/src/ui/interaction_wbtest.mbt
+++ b/selene-core/src/ui/interaction_wbtest.mbt
@@ -191,6 +191,40 @@ test "ui relative cursor positions use centered normalized coordinates" {
 }
 
 ///|
+test "ui pointer picks the pause menu dimmer above the HUD" {
+  with_ui_interaction_test_world(fn() raise {
+    reset_interaction_test_state()
+    let rect : @math.Rect = {
+      position: @math.Vec2(0.0, 0.0),
+      size: @math.Vec2(100.0, 100.0),
+    }
+    let root = spawn_interaction_test_node(rect, interactive=false)
+    let hud = spawn_interaction_test_node(rect, interactive=false)
+    let minimap = spawn_interaction_test_node(rect)
+    let pause_menu = spawn_interaction_test_node(rect, interactive=false)
+    let dimmer = spawn_interaction_test_node(rect)
+    hud.set_parent(root)
+    minimap.set_parent(hud)
+    pause_menu.set_parent(root)
+    dimmer.set_parent(pause_menu)
+    let entities = [root, hud, minimap, pause_menu, dimmer]
+    for index, entity in entities {
+      tree_orders().set(entity, index + 1)
+    }
+    z_indexes().set(minimap, ZIndex(10))
+    z_indexes().set(pause_menu, ZIndex(1))
+    z_indexes().set(dimmer, ZIndex(0))
+
+    assert_eq(resolve_pointer_target(Vec2(20.0, 20.0)), Some(dimmer))
+
+    for entity in entities.rev() {
+      cleanup_interaction_test_entity(entity)
+    }
+    reset_interaction_test_state()
+  })
+}
+
+///|
 test "ui mouse click uses the unified pointer event stream" {
   with_ui_interaction_test_world(fn() raise {
     reset_interaction_test_state()

--- a/selene-core/src/ui/interaction_wbtest.mbt
+++ b/selene-core/src/ui/interaction_wbtest.mbt
@@ -91,6 +91,7 @@ fn spawn_interaction_test_node(
   if interactive {
     buttons().set(entity, Button())
   }
+  rebuild_ui_stack()
   entity
 }
 
@@ -214,10 +215,37 @@ test "ui pointer picks the pause menu dimmer above the HUD" {
     z_indexes().set(minimap, ZIndex(10))
     z_indexes().set(pause_menu, ZIndex(1))
     z_indexes().set(dimmer, ZIndex(0))
+    rebuild_ui_stack()
 
     assert_eq(resolve_pointer_target(Vec2(20.0, 20.0)), Some(dimmer))
 
     for entity in entities.rev() {
+      cleanup_interaction_test_entity(entity)
+    }
+    reset_interaction_test_state()
+  })
+}
+
+///|
+test "ui focus candidates only include nodes in the layout stack" {
+  with_ui_interaction_test_world(fn() raise {
+    reset_interaction_test_state()
+    let root = @entity.Entity()
+    let visible = root.spawn_child()
+    let hidden = root.spawn_child()
+    nodes().set(root, Node(width=Val::px(100.0), height=Val::px(100.0)))
+    nodes().set(visible, Node(width=Val::px(50.0), height=Val::px(50.0)))
+    nodes().set(hidden, Node(display=None))
+    focusables().set(visible, Focusable())
+    focusables().set(hidden, Focusable())
+
+    ui_layout_system(0.0)
+    let candidates = focusable_entities()
+
+    assert_eq(candidates.length(), 1)
+    assert_eq(candidates[0], visible)
+
+    for entity in [hidden, visible, root] {
       cleanup_interaction_test_entity(entity)
     }
     reset_interaction_test_state()

--- a/selene-core/src/ui/layout.mbt
+++ b/selene-core/src/ui/layout.mbt
@@ -781,4 +781,5 @@ pub fn ui_layout_system(_delta : Double) -> Unit {
       layout_space,
     )
   }
+  rebuild_ui_stack()
 }

--- a/selene-core/src/ui/model.mbt
+++ b/selene-core/src/ui/model.mbt
@@ -654,6 +654,8 @@ pub fn LayoutConfig::LayoutConfig(use_rounding? : Bool = true) -> LayoutConfig {
 }
 
 ///|
+/// Orders sibling UI nodes while keeping each sibling's ordinary descendant
+/// subtree contiguous in the final UI stack.
 pub(all) struct ZIndex {
   value : Int
 } derive(Eq, Debug)
@@ -664,6 +666,8 @@ pub fn ZIndex::ZIndex(value : Int) -> ZIndex {
 }
 
 ///|
+/// Lifts a UI node and its ordinary descendants into the global UI root order.
+/// A descendant with its own `GlobalZIndex` becomes another global root.
 pub(all) struct GlobalZIndex {
   value : Int
 } derive(Eq, Debug)
@@ -888,27 +892,6 @@ fn zindex_value(entity : @entity.Entity) -> Int {
 }
 
 ///|
-fn compare_ui_stacking(lhs : @entity.Entity, rhs : @entity.Entity) -> Int {
-  let lg = global_zindex_value(lhs)
-  let rg = global_zindex_value(rhs)
-  if lg != rg {
-    return lg - rg
-  }
-  let lz = zindex_value(lhs)
-  let rz = zindex_value(rhs)
-  if lz != rz {
-    return lz - rz
-  }
-  let lt = tree_orders().get(lhs).unwrap_or(0)
-  let rt = tree_orders().get(rhs).unwrap_or(0)
-  if lt != rt {
-    lt - rt
-  } else {
-    lhs.hash().compare(rhs.hash())
-  }
-}
-
-///|
 fn compare_ui_root_order(lhs : @entity.Entity, rhs : @entity.Entity) -> Int {
   let lg = global_zindex_value(lhs)
   let rg = global_zindex_value(rhs)
@@ -1014,4 +997,89 @@ fn ui_children(entity : @entity.Entity) -> Array[@entity.Entity] {
     }
   }
   children
+}
+
+///|
+fn ui_stack() -> Array[@entity.Entity] {
+  let roots : Array[@entity.Entity] = []
+  for entity, node in nodes() {
+    guard entity.is_alive() &&
+      node.active &&
+      node.display != None &&
+      @visibility.is_visible(entity) else {
+      continue
+    }
+    let hierarchy_root = match entity.get_parent() {
+      Some(parent) =>
+        match nodes().get(parent) {
+          Some(parent_node) =>
+            !parent.is_alive() ||
+            !parent_node.active ||
+            parent_node.display == None ||
+            !@visibility.is_visible(parent)
+          None => true
+        }
+      None => true
+    }
+    if hierarchy_root || global_zindexes().contains(entity) {
+      roots.push(entity)
+    }
+  }
+  roots.sort_by(fn(lhs, rhs) {
+    let global_order = global_zindex_value(lhs) - global_zindex_value(rhs)
+    if global_order != 0 {
+      return global_order
+    }
+    let local_order = zindex_value(lhs) - zindex_value(rhs)
+    if local_order != 0 {
+      return local_order
+    }
+    let tree_order = tree_orders().get(lhs).unwrap_or(0) -
+      tree_orders().get(rhs).unwrap_or(0)
+    if tree_order != 0 {
+      tree_order
+    } else {
+      lhs.hash().compare(rhs.hash())
+    }
+  })
+  let ordered : Array[@entity.Entity] = []
+  let pending : Array[@entity.Entity] = []
+  for root in roots {
+    pending.push(root)
+    while pending.pop() is Some(entity) {
+      if global_ui_nodes().contains(entity) {
+        ordered.push(entity)
+      }
+      let children : Array[@entity.Entity] = []
+      for child in ui_children(entity) {
+        guard !global_zindexes().contains(child) else { continue }
+        guard nodes().get(child) is Some(node) &&
+          node.active &&
+          node.display != None &&
+          @visibility.is_visible(child) else {
+          continue
+        }
+        children.push(child)
+      }
+      children.sort_by(fn(lhs, rhs) {
+        let local_order = zindex_value(lhs) - zindex_value(rhs)
+        if local_order != 0 {
+          return local_order
+        }
+        let tree_order = tree_orders().get(lhs).unwrap_or(0) -
+          tree_orders().get(rhs).unwrap_or(0)
+        if tree_order != 0 {
+          tree_order
+        } else {
+          lhs.hash().compare(rhs.hash())
+        }
+      })
+      let mut index = children.length() - 1
+      while index >= 0 {
+        pending.push(children[index])
+        index -= 1
+      }
+    }
+  }
+  ordered
 }

--- a/selene-core/src/ui/model.mbt
+++ b/selene-core/src/ui/model.mbt
@@ -770,6 +770,7 @@ priv struct UiModelWorldStore {
   override_clips : Map[@entity.Entity, OverrideClip]
   relative_cursor_positions : Map[@entity.Entity, RelativeCursorPosition]
   tree_orders : Map[@entity.Entity, Int]
+  ui_stack_entities : Array[@entity.Entity]
 }
 
 ///|
@@ -795,6 +796,7 @@ fn ui_model_world_store() -> UiModelWorldStore {
     override_clips: Map([]),
     relative_cursor_positions: Map([]),
     tree_orders: Map([]),
+    ui_stack_entities: [],
   })
 }
 
@@ -879,6 +881,11 @@ pub fn relative_cursor_positions() -> Map[
 ///|
 fn tree_orders() -> Map[@entity.Entity, Int] {
   ui_model_world_store().tree_orders
+}
+
+///|
+fn ui_stack() -> Array[@entity.Entity] {
+  ui_model_world_store().ui_stack_entities
 }
 
 ///|
@@ -1000,80 +1007,81 @@ fn ui_children(entity : @entity.Entity) -> Array[@entity.Entity] {
 }
 
 ///|
-fn ui_stack() -> Array[@entity.Entity] {
+fn is_stacked_ui_entity(entity : @entity.Entity) -> Bool {
+  guard entity.is_alive() &&
+    global_ui_nodes().contains(entity) &&
+    nodes().get(entity) is Some(node) else {
+    return false
+  }
+  node.active && node.display != None && @visibility.is_visible(entity)
+}
+
+///|
+fn compare_ui_stack_root(lhs : @entity.Entity, rhs : @entity.Entity) -> Int {
+  let global_order = global_zindex_value(lhs).compare(global_zindex_value(rhs))
+  if global_order != 0 {
+    return global_order
+  }
+  let local_order = zindex_value(lhs).compare(zindex_value(rhs))
+  if local_order != 0 {
+    return local_order
+  }
+  let tree_order = tree_orders()
+    .get(lhs)
+    .unwrap_or(0)
+    .compare(tree_orders().get(rhs).unwrap_or(0))
+  if tree_order != 0 {
+    tree_order
+  } else {
+    lhs.hash().compare(rhs.hash())
+  }
+}
+
+///|
+fn compare_ui_stack_sibling(lhs : @entity.Entity, rhs : @entity.Entity) -> Int {
+  let local_order = zindex_value(lhs).compare(zindex_value(rhs))
+  if local_order != 0 {
+    return local_order
+  }
+  let tree_order = tree_orders()
+    .get(lhs)
+    .unwrap_or(0)
+    .compare(tree_orders().get(rhs).unwrap_or(0))
+  if tree_order != 0 {
+    tree_order
+  } else {
+    lhs.hash().compare(rhs.hash())
+  }
+}
+
+///|
+fn rebuild_ui_stack() -> Unit {
+  let ordered = ui_stack()
+  ordered.clear()
   let roots : Array[@entity.Entity] = []
-  for entity, node in nodes() {
-    guard entity.is_alive() &&
-      node.active &&
-      node.display != None &&
-      @visibility.is_visible(entity) else {
-      continue
-    }
+  for entity, _ in global_ui_nodes() {
+    guard is_stacked_ui_entity(entity) else { continue }
     let hierarchy_root = match entity.get_parent() {
-      Some(parent) =>
-        match nodes().get(parent) {
-          Some(parent_node) =>
-            !parent.is_alive() ||
-            !parent_node.active ||
-            parent_node.display == None ||
-            !@visibility.is_visible(parent)
-          None => true
-        }
+      Some(parent) => !is_stacked_ui_entity(parent)
       None => true
     }
     if hierarchy_root || global_zindexes().contains(entity) {
       roots.push(entity)
     }
   }
-  roots.sort_by(fn(lhs, rhs) {
-    let global_order = global_zindex_value(lhs) - global_zindex_value(rhs)
-    if global_order != 0 {
-      return global_order
-    }
-    let local_order = zindex_value(lhs) - zindex_value(rhs)
-    if local_order != 0 {
-      return local_order
-    }
-    let tree_order = tree_orders().get(lhs).unwrap_or(0) -
-      tree_orders().get(rhs).unwrap_or(0)
-    if tree_order != 0 {
-      tree_order
-    } else {
-      lhs.hash().compare(rhs.hash())
-    }
-  })
-  let ordered : Array[@entity.Entity] = []
+  roots.sort_by(compare_ui_stack_root)
   let pending : Array[@entity.Entity] = []
   for root in roots {
     pending.push(root)
     while pending.pop() is Some(entity) {
-      if global_ui_nodes().contains(entity) {
-        ordered.push(entity)
-      }
+      ordered.push(entity)
       let children : Array[@entity.Entity] = []
       for child in ui_children(entity) {
         guard !global_zindexes().contains(child) else { continue }
-        guard nodes().get(child) is Some(node) &&
-          node.active &&
-          node.display != None &&
-          @visibility.is_visible(child) else {
-          continue
-        }
+        guard is_stacked_ui_entity(child) else { continue }
         children.push(child)
       }
-      children.sort_by(fn(lhs, rhs) {
-        let local_order = zindex_value(lhs) - zindex_value(rhs)
-        if local_order != 0 {
-          return local_order
-        }
-        let tree_order = tree_orders().get(lhs).unwrap_or(0) -
-          tree_orders().get(rhs).unwrap_or(0)
-        if tree_order != 0 {
-          tree_order
-        } else {
-          lhs.hash().compare(rhs.hash())
-        }
-      })
+      children.sort_by(compare_ui_stack_sibling)
       let mut index = children.length() - 1
       while index >= 0 {
         pending.push(children[index])
@@ -1081,5 +1089,4 @@ fn ui_stack() -> Array[@entity.Entity] {
       }
     }
   }
-  ordered
 }

--- a/selene-core/src/ui/render.mbt
+++ b/selene-core/src/ui/render.mbt
@@ -924,12 +924,7 @@ fn render_target_camera_id(entity : @entity.Entity) -> UInt? {
 ///|
 pub fn ui_extract_system(_delta : Double) -> Unit {
   extracted_ui_entities.clear()
-  for entity, _ in nodes() {
-    if should_render_ui(entity) {
-      extracted_ui_entities.push(entity)
-    }
-  }
-  extracted_ui_entities.sort_by(compare_ui_stacking)
+  extracted_ui_entities.append(ui_stack())
 }
 
 ///|

--- a/selene-core/src/ui/render_wbtest.mbt
+++ b/selene-core/src/ui/render_wbtest.mbt
@@ -357,24 +357,80 @@ test "ui override clip removes inherited clip from child rendering" {
 }
 
 ///|
-test "ui stacking sorts by global z before local z and tree order" {
-  let back = @entity.Entity()
-  let front = @entity.Entity()
-  nodes().set(back, Node())
-  nodes().set(front, Node())
-  tree_orders().set(back, 5)
-  tree_orders().set(front, 1)
-  z_indexes().set(back, ZIndex(100))
-  z_indexes().set(front, ZIndex(0))
-  global_zindexes().set(back, GlobalZIndex(0))
-  global_zindexes().set(front, GlobalZIndex(1))
+test "ui stacking keeps a pause menu subtree above the HUD" {
+  let root = @entity.Entity()
+  let hud = root.spawn_child()
+  let minimap = hud.spawn_child()
+  let pause_menu = root.spawn_child()
+  let dimmer = pause_menu.spawn_child()
+  let resume_button = pause_menu.spawn_child()
+  let entities = [root, hud, minimap, pause_menu, dimmer, resume_button]
+  let rect = test_rect(0.0, 0.0, 100.0, 100.0)
+  for index, entity in entities {
+    nodes().set(entity, Node())
+    global_ui_nodes().set(entity, test_global_node(rect, rect))
+    tree_orders().set(entity, index + 1)
+  }
+  z_indexes().set(minimap, ZIndex(10))
+  z_indexes().set(pause_menu, ZIndex(1))
+  z_indexes().set(dimmer, ZIndex(0))
+  z_indexes().set(resume_button, ZIndex(20))
 
-  let entities = [front, back]
-  entities.sort_by(compare_ui_stacking)
+  ui_extract_system(0.0)
 
-  inspect(entities[0] == back, content="true")
-  inspect(entities[1] == front, content="true")
+  let mut minimap_index = -1
+  let mut pause_menu_index = -1
+  let mut dimmer_index = -1
+  for index, entity in extracted_ui_entities {
+    if entity == minimap {
+      minimap_index = index
+    } else if entity == pause_menu {
+      pause_menu_index = index
+    } else if entity == dimmer {
+      dimmer_index = index
+    }
+  }
+  assert_eq(minimap_index < pause_menu_index, true)
+  assert_eq(pause_menu_index < dimmer_index, true)
 
-  cleanup_test_ui_entity(back)
-  cleanup_test_ui_entity(front)
+  extracted_ui_entities.clear()
+  for entity in entities.rev() {
+    cleanup_test_ui_entity(entity)
+  }
+}
+
+///|
+test "global z index lifts a descendant out of its parent stack" {
+  let root = @entity.Entity()
+  let hud = root.spawn_child()
+  let minimap = hud.spawn_child()
+  let pause_menu = root.spawn_child()
+  let dimmer = pause_menu.spawn_child()
+  let entities = [root, hud, minimap, pause_menu, dimmer]
+  let rect = test_rect(0.0, 0.0, 100.0, 100.0)
+  for index, entity in entities {
+    nodes().set(entity, Node())
+    global_ui_nodes().set(entity, test_global_node(rect, rect))
+    tree_orders().set(entity, index + 1)
+  }
+  z_indexes().set(pause_menu, ZIndex(1))
+  global_zindexes().set(minimap, GlobalZIndex(2))
+
+  ui_extract_system(0.0)
+
+  let mut dimmer_index = -1
+  let mut minimap_index = -1
+  for index, entity in extracted_ui_entities {
+    if entity == dimmer {
+      dimmer_index = index
+    } else if entity == minimap {
+      minimap_index = index
+    }
+  }
+  assert_eq(dimmer_index < minimap_index, true)
+
+  extracted_ui_entities.clear()
+  for entity in entities.rev() {
+    cleanup_test_ui_entity(entity)
+  }
 }

--- a/selene-core/src/ui/render_wbtest.mbt
+++ b/selene-core/src/ui/render_wbtest.mbt
@@ -51,6 +51,19 @@ fn cleanup_test_ui_entity(entity : @entity.Entity) -> Unit {
 }
 
 ///|
+fn test_entity_index(
+  entities : Array[@entity.Entity],
+  target : @entity.Entity,
+) -> Int {
+  for index, entity in entities {
+    if entity == target {
+      return index
+    }
+  }
+  -1
+}
+
+///|
 test "ui rounded backgrounds emit quarter-circle fill commands" {
   @render2d.begin_frame2d_system(0.0)
   let entity = @entity.Entity()
@@ -365,17 +378,15 @@ test "ui stacking keeps a pause menu subtree above the HUD" {
   let dimmer = pause_menu.spawn_child()
   let resume_button = pause_menu.spawn_child()
   let entities = [root, hud, minimap, pause_menu, dimmer, resume_button]
-  let rect = test_rect(0.0, 0.0, 100.0, 100.0)
-  for index, entity in entities {
-    nodes().set(entity, Node())
-    global_ui_nodes().set(entity, test_global_node(rect, rect))
-    tree_orders().set(entity, index + 1)
+  for entity in entities {
+    nodes().set(entity, Node(width=Val::px(100.0), height=Val::px(100.0)))
   }
   z_indexes().set(minimap, ZIndex(10))
   z_indexes().set(pause_menu, ZIndex(1))
   z_indexes().set(dimmer, ZIndex(0))
   z_indexes().set(resume_button, ZIndex(20))
 
+  ui_layout_system(0.0)
   ui_extract_system(0.0)
 
   let mut minimap_index = -1
@@ -407,15 +418,13 @@ test "global z index lifts a descendant out of its parent stack" {
   let pause_menu = root.spawn_child()
   let dimmer = pause_menu.spawn_child()
   let entities = [root, hud, minimap, pause_menu, dimmer]
-  let rect = test_rect(0.0, 0.0, 100.0, 100.0)
-  for index, entity in entities {
-    nodes().set(entity, Node())
-    global_ui_nodes().set(entity, test_global_node(rect, rect))
-    tree_orders().set(entity, index + 1)
+  for entity in entities {
+    nodes().set(entity, Node(width=Val::px(100.0), height=Val::px(100.0)))
   }
   z_indexes().set(pause_menu, ZIndex(1))
   global_zindexes().set(minimap, GlobalZIndex(2))
 
+  ui_layout_system(0.0)
   ui_extract_system(0.0)
 
   let mut dimmer_index = -1
@@ -428,6 +437,72 @@ test "global z index lifts a descendant out of its parent stack" {
     }
   }
   assert_eq(dimmer_index < minimap_index, true)
+
+  extracted_ui_entities.clear()
+  for entity in entities.rev() {
+    cleanup_test_ui_entity(entity)
+  }
+}
+
+///|
+test "global z index orders separate UI roots before local z index" {
+  let local_front = @entity.Entity()
+  let global_front = @entity.Entity()
+  let entities = [local_front, global_front]
+  for entity in entities {
+    nodes().set(entity, Node(width=Val::px(100.0), height=Val::px(100.0)))
+  }
+  z_indexes().set(local_front, ZIndex(100))
+  global_zindexes().set(local_front, GlobalZIndex(0))
+  z_indexes().set(global_front, ZIndex(0))
+  global_zindexes().set(global_front, GlobalZIndex(1))
+
+  ui_layout_system(0.0)
+  ui_extract_system(0.0)
+
+  assert_eq(
+    test_entity_index(extracted_ui_entities, local_front) <
+    test_entity_index(extracted_ui_entities, global_front),
+    true,
+  )
+
+  extracted_ui_entities.clear()
+  for entity in entities {
+    cleanup_test_ui_entity(entity)
+  }
+}
+
+///|
+test "ui extraction reuses the stack snapshot produced by layout" {
+  let root = @entity.Entity()
+  let first = root.spawn_child()
+  let second = root.spawn_child()
+  let entities = [root, first, second]
+  for entity in entities {
+    nodes().set(entity, Node(width=Val::px(100.0), height=Val::px(100.0)))
+  }
+  z_indexes().set(first, ZIndex(0))
+  z_indexes().set(second, ZIndex(1))
+
+  ui_layout_system(0.0)
+  z_indexes().set(first, ZIndex(2))
+  ui_extract_system(0.0)
+  let first_snapshot = extracted_ui_entities.copy()
+
+  ui_layout_system(0.0)
+  ui_extract_system(0.0)
+  let second_snapshot = extracted_ui_entities.copy()
+
+  assert_eq(
+    test_entity_index(first_snapshot, first) <
+    test_entity_index(first_snapshot, second),
+    true,
+  )
+  assert_eq(
+    test_entity_index(second_snapshot, second) <
+    test_entity_index(second_snapshot, first),
+    true,
+  )
 
   extracted_ui_entities.clear()
   for entity in entities.rev() {


### PR DESCRIPTION
## Summary

- order `ZIndex` among siblings while keeping ordinary descendant subtrees contiguous
- treat explicit `GlobalZIndex` nodes as independent global roots
- use the same final UI stack for rendering, focus traversal, and pointer hit-testing

This keeps a pause-menu subtree above an existing HUD subtree while preserving an explicit global escape point for overlays.

Fixes #53

## Checks

- `moon test selene-core/src/ui/render_wbtest.mbt --target js`
- `moon test selene-core/src/ui/interaction_wbtest.mbt --target js`
- `moon test selene-core/src/ui --target js`
- `moon test selene-core/src/ui --target native`
- `moon check --target all --deny-warn`